### PR TITLE
Ignore Commented (@) Lines

### DIFF
--- a/IPS.NET.Core/Converters/PchtxtToIPS.cs
+++ b/IPS.NET.Core/Converters/PchtxtToIPS.cs
@@ -97,6 +97,9 @@ public class PchtxtToIPS
                             break;
                     }
                     break;
+                case '@':
+                    state = State.Comment;
+                    break;
                 default:
                     switch (state) {
                         case State.Address:


### PR DESCRIPTION
Skips lines prefixed with the `@` (comment) symbol.